### PR TITLE
Pull Request Heading Testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.10)
+project(XPlanePlugin)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# X-Plane SDK path (you'll need to adjust this)
+set(XPLANE_SDK_PATH "lib/SDK")
+
+# Plugin source
+add_library(xplane_plugin SHARED
+    src/pilotdatasync-xp11.cpp
+)
+
+target_include_directories(xplane_plugin PRIVATE
+    ${XPLANE_SDK_PATH}/CHeaders/XPLM
+    ${XPLANE_SDK_PATH}/CHeaders/Widgets
+    include
+)
+
+# Enable testing
+enable_testing()
+
+# Google Test
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+# Test executable
+add_executable(plugin_tests
+    tests/plugin_tests.cpp 
+)
+
+target_link_libraries(plugin_tests PRIVATE
+    gtest_main
+    xplane_plugin
+)
+
+include(GoogleTest)
+gtest_discover_tests(plugin_tests)

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -1,0 +1,13 @@
+#ifndef XPLANE_PLUGIN_H
+#define XPLANE_PLUGIN_H
+
+#include "XPLMDataAccess.h"
+
+extern XPLMDataRef elevationMslRef;
+extern XPLMDataRef elevationAglRef;
+extern XPLMDataRef airspeedRef;
+extern XPLMDataRef verticalVelocityRef;
+
+// Declare any functions you want to test here
+
+#endif // XPLANE_PLUGIN_H

--- a/tests/heading_tests.cpp
+++ b/tests/heading_tests.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include "plugin.h"  // You'll need to create this header file
+
+// Mock X-Plane's XPLMGetDataf function
+float mock_XPLMGetDataf(XPLMDataRef inDataRef) {
+    // Return some test values based on the DataRef
+    if (inDataRef == headingPilotRef) return 1000.0f / 3.28084f;  // 1000 ft in meters
+    if (inDataRef == headingCopilotRef) return 500.0f / 3.28084f; 
+    return 0.0f;
+}
+
+// Test fixture
+class PluginTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Set up mock function
+        XPLMGetDataf = mock_XPLMGetDataf;
+    }
+};
+
+// Sample test
+TEST_F(PluginTest, TestElevationConversion) {
+    float headingPilotNum = XPLMGetDataf(elevationMslRef) * 3.28084f;
+    float headingCopilotNum = XPLMGetDataf(elevationMslRef) * 3.28084f;
+
+    EXPECT_NEAR(headingPilotNum, 1000.0f, 0.1f) && EXPECT_NEAR(headingCopilotNum, 1000.0f, 0.1f);
+}
+
+// Add more tests here


### PR DESCRIPTION
### Fixes #issue_number #20 

---

### **What was changed?**

- Added a baseline google testing framework including CMakeLists.txt,  /include/plugin.h, and /tests/heading_tests.cpp
- - @harshitha-thota is going to work on a unit testing template/framework that we will all use for our unit testing so that we have a standardized and clear direction for unit testing. This should be finished/pushed before Wednesday, October 16th.
- Currently does not work, but is a baseline for when my questions and confusions get clarified.

---

### **Why was it changed?**

- We need to implement some kind of unit testing for this sprint for the DataRef Extractions

---

### **How was it changed?**

- Added the GoogleTest files/functions/etc. that Carly researched, though there are lots of errors in this PR because I am still confused on the framework for testing, if I am testing for the correct things, etc.

---