### PR TITLE
Threading fixes to assist in completion of PR #46

### DIFF
--- a/include/threading-tools.h
+++ b/include/threading-tools.h
@@ -12,11 +12,11 @@
 using namespace std;
 
 struct ThreadMessage {
-    const float* values_for_packet;
+    const float values_for_packet[4];
     const bool end_execution_flag;
 
-    ThreadMessage(float const (&values_for_packet)[4], const bool tf) :
-        values_for_packet(values_for_packet),
+    ThreadMessage(float const (&values)[4], const bool tf) :
+        values_for_packet{ values[0], values[1], values[2], values[3] },
         end_execution_flag(tf) {};
 };
 


### PR DESCRIPTION
Relates to #46 

- Added ThreadQueue to refcon void pointer (resource package passed to flight loop for use)
- Moved TCP thread spin-up from plugin start callback to plugin enable callback
- Refactored ThreadQueue to copy array values (was previously pointing to garbage data)
- Stored ThreadQueue in a shared pointer for better memory management

The test pattern is a series of four float packets incrementing from 1 to 3, then a final packet with the execution flag included.

The TCP server now works with these changes. Evidence from the log:
```[Fri Nov 22 12:05:58 2024] Server connection successful
[Fri Nov 22 12:07:51 2024] Generating packet: 1.000000;1.000000;1.000000;1.000000;

[Fri Nov 22 12:07:52 2024] Packet sent successfully
[Fri Nov 22 12:07:52 2024] Generating packet: 2.000000;2.000000;2.000000;2.000000;

[Fri Nov 22 12:07:52 2024] Packet sent successfully
[Fri Nov 22 12:07:52 2024] Generating packet: 3.000000;3.000000;3.000000;3.000000;

[Fri Nov 22 12:07:52 2024] Packet sent successfully
[Fri Nov 22 12:07:52 2024] Received end execution flag
```

Server's perspective:
```TCP Server Starting...
Server starting up...
Initializing Winsock...
Winsock initialized successfully!
Creating socket...
Socket created successfully.
Binding socket to port 8089...
Socket bound successfully.
Starting to listen for connections...
Server listening on port 8089
Waiting for client connection...
Client connected from IP: 127.0.0.1
Ready to receive data...
Waiting for data...
Received 38 bytes: 1.000000;1.000000;1.000000;1.000000;

Waiting for data...
Received 76 bytes: 2.000000;2.000000;2.000000;2.000000;
3.000000;3.000000;3.000000;3.000000;

Waiting for data...
Client disconnected.
Server shutting down...
Client socket closed.
Server socket closed.
Server shut down.
```