### PR TITLE
client server rust

### DIFF
--- a/src/clientserver/src/client.rs
+++ b/src/clientserver/src/client.rs
@@ -1,0 +1,35 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::str::from_utf8;
+
+fn main() -> std::io::Result<()> {
+    // Connect to the server
+    match TcpStream::connect("127.0.0.1:7878") {
+        Ok(mut stream) => {
+            println!("Successfully connected to server at 127.0.0.1:7878");
+            
+            // Send a message to the server
+            let message = "Hello from the Rust TCP client!";
+            stream.write(message.as_bytes())?;
+            println!("Sent: {}", message);
+            
+            // Buffer to store server response
+            let mut buffer = [0; 1024];
+            match stream.read(&mut buffer) {
+                Ok(size) => {
+                    // Convert the received bytes to a string
+                    let response = from_utf8(&buffer[0..size]).unwrap();
+                    println!("Received: {}", response);
+                }
+                Err(e) => {
+                    eprintln!("Failed to receive response: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to connect: {}", e);
+        }
+    }
+    
+    Ok(())
+}

--- a/src/clientserver/src/server.rs
+++ b/src/clientserver/src/server.rs
@@ -1,0 +1,49 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+fn handle_client(mut stream: TcpStream) {
+    // Buffer to store incoming data
+    let mut buffer = [0; 1024];
+    
+    match stream.read(&mut buffer) {
+        Ok(size) => {
+            // Convert the received bytes to a string
+            let received = String::from_utf8_lossy(&buffer[0..size]);
+            println!("Received: {}", received);
+            
+            // Echo the message back with a prefix
+            let response = format!("Server received: {}", received);
+            match stream.write(response.as_bytes()) {
+                Ok(_) => println!("Response sent"),
+                Err(e) => eprintln!("Failed to send response: {}", e),
+            }
+        }
+        Err(e) => eprintln!("Failed to receive data: {}", e),
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    // Create a listener bound to address 127.0.0.1:7878
+    let listener = TcpListener::bind("127.0.0.1:7878")?;
+    println!("Server listening on port 7878");
+
+    // Listen for incoming connections
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                println!("New connection: {}", stream.peer_addr().unwrap());
+                
+                // Spawn a new thread for each connection
+                thread::spawn(move || {
+                    handle_client(stream);
+                });
+            }
+            Err(e) => {
+                eprintln!("Connection failed: {}", e);
+            }
+        }
+    }
+    
+    Ok(())
+}


### PR DESCRIPTION
### Fixes #86 

---

### **What was changed?**

-added a client and a server file to the src file located in dir 'clientserver' 
---

### **Why was it changed?**

- Adds functionality for rust tcp to be used for later 
---

### **How was it changed?**

-added to src 
-add name and path to cargo.toml to run files from command line as such 'cargo run --bin server' 
---

### **Screenshots (if applicable):**

![image_2025-03-03_012323331](https://github.com/user-attachments/assets/de6ef8d7-15ee-4094-8124-5a7cf8a9293a)

