### PR TITLE
Fixes #90

### DIFF
--- a/xplane_plugin/src/pilotdatasync-xp11.cpp
+++ b/xplane_plugin/src/pilotdatasync-xp11.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <memory>
 
 #include "Logger.cpp"
 #include "TCPClient.cpp"

--- a/xplane_plugin/src/pilotdatasync-xp11.cpp
+++ b/xplane_plugin/src/pilotdatasync-xp11.cpp
@@ -3,10 +3,10 @@
 // https://developer.x-plane.com/code-sample/hello-world-sdk-3/
 
 #include <cmath>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
-#include <memory>
 
 #include "Logger.cpp"
 #include "TCPClient.cpp"


### PR DESCRIPTION
### Fixes #90 

The last PR was failing the CI build due to Meson needing the `memory` header. 

### **What was changed?**

- Added `#include <memory>` to the XPlane plugin file to remove Meson include errors.

### **Why was it changed?**

- The C++ compiler for GitHub Actions workflow requires this include as it uses a different version of the STL as the compiler that we run on our local machines. This could be changed, but it would take too much effort when the C++ threading behavior that requires these imports will be removed in this sprint.
