### PR TITLE
93 implement baton retry mechanism

### DIFF
--- a/xplane_plugin/src/pilotdatasync-xp11.cpp
+++ b/xplane_plugin/src/pilotdatasync-xp11.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <memory>
 
 #include "Logger.cpp"
 #include "TCPClient.cpp"

--- a/xplane_plugin/src/pilotdatasync-xp11.cpp
+++ b/xplane_plugin/src/pilotdatasync-xp11.cpp
@@ -3,10 +3,10 @@
 // https://developer.x-plane.com/code-sample/hello-world-sdk-3/
 
 #include <cmath>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
-#include <memory>
 
 #include "Logger.cpp"
 #include "TCPClient.cpp"


### PR DESCRIPTION
### Fixes #93 and #90 

### **What was changed?**

- For 90, fixed the build system failing our builds because of the xplane plugin file.
- For 93, added a retry connection mechanism in the baton subproject.

### **Why was it changed?**

- For 90, The C++ compiler for the GitHub Actions workflow "Meson Build System" requires this include as it uses a different version of the STL as the compiler that we run on our local machines. This compiler could be changed, but it would take too much effort when the C++ threading behavior that throws this error will be removed in this sprint.
- For 93, the mechanism was added so that no matter whether Relay or XPlane started first, the project would eventually connect.

### **How was it changed?**

- For 90, added the `#include <memory>` header in the xplane plugin file to deal with the Meson build errors that were happening.
- For 93, added the retry mechanism in the baton lib.rs file. I changed the single connection request into an infinite reconnect loop with an exponential backoff that starts at 100ms and caps off at 5 seconds. These numbers can be adjusted if desired.


I combined these two fixes into one PR as the CI fix was easy enough to fix.