### PR TITLE
Default XML Creation

### DIFF
--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -1420,6 +1420,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_aw"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "582c517a94ce3205da98e9c10b26bb71aa36b7d7d084441d826dc912711d1bac"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.1",
+ "iced",
+ "iced_fonts",
+ "web-time",
+]
+
+[[package]]
 name = "iced_core"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1450,15 @@ dependencies = [
  "smol_str",
  "thiserror",
  "web-time",
+]
+
+[[package]]
+name = "iced_fonts"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7deb0800a850ee25c8a42559f72c0f249e577feb3aad37b9b65dc1e517e52a"
+dependencies = [
+ "iced_core",
 ]
 
 [[package]]
@@ -2600,6 +2622,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "iced",
+ "iced_aw",
  "interprocess",
 ]
 

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -5,5 +5,7 @@ edition = "2021"
 
 [dependencies]
 iced = { version = "*", features = ["tokio"] }
+iced_aw = { version = "0.12.0", default-features = false, features = ["card"] }
+
 anyhow = "*"
 interprocess = "*"

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -112,6 +112,13 @@ fn main() -> iced::Result {
                 recv: Some(recv),
                 connection_status: None,
                 active_baton_connection: false,
+
+                // Variables for the UI XML Creation toggles
+                card_open: false,
+                altitude_toggle: true,
+                airspeed_toggle: true,
+                vertical_airspeed_toggle: true,
+                other_toggle: true,
             };
             (state, Task::none())
         })

--- a/relay/src/message.rs
+++ b/relay/src/message.rs
@@ -10,6 +10,17 @@ pub(crate) enum Message {
     BatonMessage,
 
     ConnectionMessage,
+
+    CreateXMLFile,
+
+    // Toggle buttons to generate XML file in UI
+    AltitudeToggle(bool),
+    AirspeedToggle(bool),
+    VerticalAirspeedToggle(bool),
+    OtherToggle(bool),
+    
+    CardOpen,
+    CardClose,
 }
 
 // Enum for messages from within the IPC connection thread

--- a/relay/src/state.rs
+++ b/relay/src/state.rs
@@ -17,4 +17,11 @@ pub(crate) struct State {
     pub latest_baton_send: Option<String>,
     pub active_baton_connection: bool,
     pub recv: Option<std::sync::mpsc::Receiver<ChannelMessage>>,
+
+    pub card_open: bool, 
+    pub altitude_toggle: bool,
+    pub airspeed_toggle: bool,
+    pub vertical_airspeed_toggle: bool,
+    pub other_toggle: bool,
+
 }

--- a/relay/src/update.rs
+++ b/relay/src/update.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+use std::io::prelude::*;
 use iced::{time::Duration, Task};
 
 use crate::{IpcThreadMessage, Message, State};
@@ -44,15 +46,76 @@ pub(crate) fn update(state: &mut State, message: Message) -> Task<Message> {
             };
             Task::none()
         }
-
-      M::ConnectionMessage => {
-        println!("Check Connection Status");
-        if let Some(status) = state.recv.as_ref().and_then(|recv| recv.try_recv().ok()){
-            state.connection_status = Some(status)
-        }                                                                                           
-        Task::none()
-            
+        M::ConnectionMessage => {
+            println!("Check Connection Status");
+            if let Some(status) = state.recv.as_ref().and_then(|recv| recv.try_recv().ok()){
+                state.connection_status = Some(status)
+            }                                                                                           
+            Task::none() 
         },
+        // Toggle messages for GUI XML generator
+        M::AltitudeToggle(value) => {
+            state.altitude_toggle = value;
+            Task::none()
+        },
+        M::AirspeedToggle(value) => {
+            state.altitude_toggle = value;
+            Task::none()
+        },
+        M::VerticalAirspeedToggle(value) => {
+            state.altitude_toggle = value;
+            Task::none()
+        },
+        M::OtherToggle(value) => {
+            state.altitude_toggle = value;
+            Task::none()
+        },
+        M::CreateXMLFile => {
+            create_xml_file(state)
+        },
+        // Card Open/Close messages for GUI pop-up-card window
+        M::CardOpen => {
+            state.card_open = true;
+            Task::none()
+        }
+        M::CardClose => {
+            state.card_open = false;
+            Task::none()
+        }
         _ => Task::none(),
     }
+}
+
+
+
+// Creates a default XML file when a button is clicked in the GUI
+fn create_xml_file(state: &mut State) -> Task<Message> {
+    // FIXME: How to make this file show up in the Downloads folder? Or do I want to just have file download in project root?
+    let mut file = File::create("iMotions.xml").expect("Creating XML File");
+
+    // TODO: Check if all datarefs are false. If so, don't generate anything? or figure this out ngl
+
+    // TODO: Replace this with actual xml file contents. Get from the XPlane API.
+    let mut contents = String::from("xml document header\n");
+    if state.altitude_toggle {
+        // add altitude dataref to contents
+        contents.push_str("Altitude\n");
+    }
+    if state.airspeed_toggle {
+        // add airspeed dataref to contents
+        contents.push_str("Airspeed\n");
+    }
+    if state.vertical_airspeed_toggle {
+        // add vertical airspeed to contents
+        contents.push_str("Vertical Airspeed\n");
+    }
+    if state.other_toggle {
+        // add other_toggle dataref to contents
+        contents.push_str("Other\n");
+    }
+
+    // Write contents to that file
+    file.write_all(contents.as_bytes()).expect("Writing to XML file");   
+
+    Task::none()    // Return that we need for the Update logic
 }

--- a/relay/src/view.rs
+++ b/relay/src/view.rs
@@ -1,7 +1,8 @@
 use iced::{
-    widget::{button, column, container, text},
+    widget::{button, column, container, text, toggler},
     Element,
 };
+use iced_aw::{helpers::card, style};
 
 use crate::{Message, State};
 
@@ -28,12 +29,55 @@ pub(crate) fn view(state: &State) -> Element<Message> {
         text(format!("Elapsed time: {:?}", state.elapsed_time)),
         text(baton_data),
         text(format!("Connection Staus: {}", connection_status)),
+        // create_toggle_button(state),
+        // create_xml_button(state),
+        xml_downloader_popup(state),
         button("Check Connection Status").on_press(Message::ConnectionMessage),
         // if we use containers, it boxes up the text elements and makes them easier to read
         container(text(baton_connect_status))
             .padding(10)
             .center(400)
-            .style(container::rounded_box)
+            .style(container::rounded_box),
     ]
     .into()
+}
+
+
+// fn create_toggle_button(state: &State) -> Element<Message> {
+//     toggler(state.toggler_button_is_checked)
+//         .label("Toggle Button!")
+//         .on_toggle(Message::ToggleMessage)
+//         .into()
+// }
+
+fn xml_downloader_popup(state: &State) -> Element<Message> {
+    if state.card_open {
+        card(
+                // FIXME: reword these toggles to actually be snappy wording
+                text(format!("Download the XML File!")),
+                column![
+                    toggler(state.altitude_toggle)
+                        .label("Altitude Toggle!")
+                        .on_toggle(Message::AltitudeToggle),
+                    toggler(state.airspeed_toggle)
+                        .label("Airspeed Toggle")
+                        .on_toggle(Message::AirspeedToggle),
+                    toggler(state.vertical_airspeed_toggle)
+                        .label("Vertical Airspeed Toggle")
+                        .on_toggle(Message::VerticalAirspeedToggle),
+                    toggler(state.other_toggle)
+                        .label("Other Toggle")
+                        .on_toggle(Message::OtherToggle),
+                    button("Generate XML File").on_press(Message::CreateXMLFile),
+                ]
+        )
+            //.foot(text(format!("Foot")))
+            .style(style::card::primary)
+            .on_close(Message::CardClose)
+            .into()
+    } else {
+        button("Open XML Download Menu")
+            .on_press(Message::CardOpen)
+            .into()
+    }
 }


### PR DESCRIPTION
### Fixes #108 

### **What was changed?**

- Added a clickable GUI element that expands into a screen with
1. toggle buttons for datarefs
2. button to generate an XML based on the toggled datarefs

### **Why was it changed?**

- We need a way to generate an XML file for the project, or at least a consistent space to store the file for our client. I figured that generating it inside the GUI would be easy enough and that the client could then email it to herself and the iMotions computer.

### **How was it changed?**

- Added a function in the `view.rs` file that will generate the XML creator button/pop-up
- Changed `message.rs` file to add messages for the dataref toggles. I tried to stick these in their own separate enum, but ICED didn't like that and they now live inside the main message enum.
- Changed `update.rs` file to include a function that creates the XML file and to mutate the state of the button toggles
- Changed `state.rs` file to include some boolean values that the toggle buttons mutate.
