### PR TITLE
Mid-Sprint Concept for #109 Add a status indicator to the Relay GUI that shows packet transfer rate over TCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # GitHub Actions leftovers
 **/github_conf
+
+# Auto-generated iMotions.xml file from GUI
+iMotions.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,12 @@ When making changes to the codebase, it's important to keep the documentation up
 - Add or update code comments to explain complex or non-obvious parts of the code.
 - Include any necessary configuration or setup instructions for new features or changes.
 
+## UI Guidelines: 
+`relay/src/view.rs`
+- All ICED UI elements must be placed in standalone helper functions.
+- The main `view()` function should only **compose** these elements, not build them directly.
+- This makes the codebase modular and readable for future contributors.
+
 ## Writing Unit Tests
 
 We encourage contributors to write unit tests for their code changes to ensure the stability and reliability of the project. When writing unit tests:

--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -797,7 +797,7 @@ checksum = "2a76fa97167fa740dcdbfe18e8895601e1bc36525f09b044e00916e717c03a3c"
 dependencies = [
  "dconf_rs",
  "detect-desktop-environment",
- "dirs",
+ "dirs 4.0.0",
  "objc",
  "rust-ini",
  "web-sys",
@@ -833,7 +833,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -845,6 +854,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1451,6 +1472,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_aw"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "582c517a94ce3205da98e9c10b26bb71aa36b7d7d084441d826dc912711d1bac"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.1",
+ "iced",
+ "iced_fonts",
+ "web-time",
+]
+
+[[package]]
 name = "iced_core"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1502,15 @@ dependencies = [
  "smol_str",
  "thiserror",
  "web-time",
+]
+
+[[package]]
+name = "iced_fonts"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7deb0800a850ee25c8a42559f72c0f249e577feb3aad37b9b65dc1e517e52a"
+dependencies = [
+ "iced_core",
 ]
 
 [[package]]
@@ -2200,6 +2243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,7 +2680,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "crossbeam",
+ "dirs 5.0.1",
  "iced",
+ "iced_aw",
  "interprocess",
 ]
 
@@ -3680,6 +3731,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 iced = { version = "*", features = ["tokio"] }
+iced_aw = { version = "0.12.0", default-features = false, features = ["card"] }
+dirs = "5.0"
 anyhow = "*"
 interprocess = "*"
 crossbeam = "0.8.4"

--- a/relay/src/channel.rs
+++ b/relay/src/channel.rs
@@ -2,6 +2,5 @@
 pub enum ChannelMessage {
     Connect,
     #[default]
-    Disconnected, 
+    Disconnected,
 }
-

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -53,7 +53,6 @@ fn main() -> iced::Result {
         .run_with(|| {
             // for pre-run state initialization
             let mut state = State {
-                elapsed_time: Duration::ZERO,
                 ..Default::default()
             };
 

--- a/relay/src/message.rs
+++ b/relay/src/message.rs
@@ -8,6 +8,18 @@ pub(crate) enum Message {
 
     ConnectionMessage,
 
+    CreateXMLFile,
+
+    // Toggle buttons to generate XML file in UI
+    AltitudeToggle(bool),
+    AirspeedToggle(bool),
+    VerticalAirspeedToggle(bool),
+    HeadingToggle(bool),
+
+    // Messages for the GUI Card pop-up
+    CardOpen,
+    CardClose,
+
     ConnectIpc,
 
     DisconnectIpc,

--- a/relay/src/update.rs
+++ b/relay/src/update.rs
@@ -1,4 +1,6 @@
 use iced::{time::Duration, Task};
+use std::fs::File;
+use std::io::prelude::*;
 
 use crate::{message::ToTcpThreadMessage, FromIpcThreadMessage, Message, State};
 
@@ -9,6 +11,12 @@ pub(crate) fn update(state: &mut State, message: Message) -> Task<Message> {
     match message {
         M::Update => {
             state.elapsed_time += Duration::from_millis(10);
+
+
+            // code for tcp packet count -Nyla Hughes
+            state.refresh_click_metrics();
+            //
+
 
             // check for messages from IPC thread
             if let Some(ipc_bichannel) = &state.ipc_bichannel {
@@ -76,6 +84,12 @@ pub(crate) fn update(state: &mut State, message: Message) -> Task<Message> {
             } else {
                 state.tcp_connected = false
             }
+
+            //added for tcp connection status button -Nyla Hughes
+             state.record_click();
+             state.refresh_click_metrics();
+             //
+
             Task::none()
         }
         M::ConnectIpc => {
@@ -103,6 +117,33 @@ pub(crate) fn update(state: &mut State, message: Message) -> Task<Message> {
             };
             Task::none()
         }
+        // Toggle messages for GUI XML generator
+        M::AltitudeToggle(value) => {
+            state.altitude_toggle = value;
+            Task::none()
+        }
+        M::AirspeedToggle(value) => {
+            state.airspeed_toggle = value;
+            Task::none()
+        }
+        M::VerticalAirspeedToggle(value) => {
+            state.vertical_airspeed_toggle = value;
+            Task::none()
+        }
+        M::HeadingToggle(value) => {
+            state.heading_toggle = value;
+            Task::none()
+        }
+        M::CreateXMLFile => create_xml_file(state),
+        // Card Open/Close messages for GUI pop-up-card window
+        M::CardOpen => {
+            state.card_open = true;
+            Task::none()
+        }
+        M::CardClose => {
+            state.card_open = false;
+            Task::none()
+        }
         M::TcpAddrFieldUpdate(addr) => {
             // Update the TCP address text input in the GUI
             let is_chars_valid = addr.chars().all(|c| c.is_numeric() || c == '.' || c == ':');
@@ -115,4 +156,91 @@ pub(crate) fn update(state: &mut State, message: Message) -> Task<Message> {
         }
         _ => Task::none(),
     }
+}
+
+// Creates a default XML file when a button is clicked in the GUI
+fn create_xml_file(state: &mut State) -> Task<Message> {
+    // Get the user's downloads directory
+    let mut downloads_path =
+        dirs::download_dir().expect("Retrieving the user's Downloads file directory.");
+    downloads_path.push("iMotions.xml");
+
+    // Create file in downloads directory. If alr there, will overwrite the existing file.
+    let mut file = File::create(&downloads_path).expect("Creating XML File.");
+
+    // Check if all dataref toggles are false. If so, return error message
+    if !state.altitude_toggle
+        && !state.airspeed_toggle
+        && !state.vertical_airspeed_toggle
+        && !state.heading_toggle
+    {
+        state.error_message = Some("Please select at least one dataref toggle".into());
+        return Task::none();
+    }
+    state.error_message = None; // Clear previous error
+
+    // NOTE: This XML formatting was found in the PilotDataSync Slack. Double check this is the correct formatting.
+    let mut contents = String::from(
+        "<EventSource Version=\"1\" Id=\"PilotDataSync\" Name=\"Positional Flight Data\">\n",
+    );
+    if state.altitude_toggle {
+        let mut altitude_str =
+            String::from("\t<Sample Id=\"AltitudeSync\" Name=\"Altitude Synchronization\">\n");
+
+        altitude_str.push_str(
+            "\t\t<Field Id=\"FlightModelAltitude\" Range=\"Variable\" Min=\"0\" Max=\"50000\" />\n",
+        );
+        altitude_str.push_str(
+            "\t\t<Field Id=\"PilotAltitude\" Range=\"Variable\" Min=\"0\" Max=\"50000\" />\n",
+        );
+        altitude_str.push_str("\t</Sample>\n");
+
+        contents.push_str(&altitude_str);
+    }
+    if state.airspeed_toggle {
+        let mut airspeed_str =
+            String::from("\t<Sample Id=\"AirspeedSync\" Name=\"Airspeed Synchronization\">\n");
+
+        airspeed_str.push_str(
+            "\t\t<Field Id=\"FlightModelAirspeed\" Range=\"Variable\" Min=\"0\" Max=\"600\" />\n",
+        );
+        airspeed_str.push_str(
+            "\t\t<Field Id=\"PilotAirspeed\" Range=\"Variable\" Min=\"0\" Max=\"600\" />\n",
+        );
+        airspeed_str.push_str("\t</Sample>\n");
+
+        contents.push_str(&airspeed_str);
+    }
+    if state.vertical_airspeed_toggle {
+        let mut vertical_airspeed_str = String::from(
+            "\t<Sample Id=\"VerticalVelocitySync\" Name=\"Vertical Velocity Synchronization\">\n",
+        );
+
+        vertical_airspeed_str.push_str("\t\t<Field Id=\"FlightModelVerticalVelocity\" Range=\"Variable\" Min=\"-5000\" Max=\"5000\" />\n");
+        vertical_airspeed_str.push_str("\t\t<Field Id=\"PilotVerticalVelocity\" Range=\"Variable\" Min=\"-5000\" Max=\"5000\" />\n");
+        vertical_airspeed_str.push_str("\t</Sample>\n");
+
+        contents.push_str(&vertical_airspeed_str);
+    }
+    if state.heading_toggle {
+        let mut heading_str =
+            String::from("\t<Sample Id=\"HeadingSync\" Name=\"Heading Synchronization\">\n");
+
+        heading_str.push_str(
+            "\t\t<Field Id=\"FlightModelHeading\" Range=\"Variable\" Min=\"0\" Max=\"360\" />\n",
+        );
+        heading_str.push_str(
+            "\t\t<Field Id=\"PilotHeading\" Range=\"Variable\" Min=\"0\" Max=\"360\" />\n",
+        );
+        heading_str.push_str("\t</Sample>\n");
+
+        contents.push_str(&heading_str);
+    }
+    contents.push_str("</EventSource>");
+
+    // Write XML file
+    file.write_all(contents.as_bytes())
+        .expect("Writing to XML file");
+
+    Task::none() // Return type that we need for the Update logic
 }

--- a/relay/src/view.rs
+++ b/relay/src/view.rs
@@ -1,58 +1,199 @@
+//! This module defines the UI View layout using ICED.
+//!
+//! UI elements should be defined as **separate functions** and added to the UI elements vector
+//! instead of being written inline in the `view` function.
+//!
+//! This improves modularity, testing, and code readability.
+//!
+//! Examples:
+//!     ```fn spawn_error_message(state: &State) -> Option<UIElement> { /* ... */ } ```
+//!     ``` if let Some(error_element) = spawn_error_message(state) {
+//!             elements.push(error_element.into());
+//!         }   ```
+//!
+//!     ``` fn ipc_disconnect_button(_state: &State) -> UIElement {/* ... */}   ```
+//!     ``` elements.push(tcp_disconnect_button(state)); ```
+
 use std::net::ToSocketAddrs;
 
 use iced::{
-    widget::{button, column, container, row, text, text_input},
-    Element,
+    widget::{button, column, container, row, text, text_input, toggler},
+    Element, Length,
 };
+use iced_aw::{helpers::card, style};
 
 use crate::{Message, State};
 
-pub(crate) fn view(state: &State) -> Element<Message> {
+type UIElement<'a> = Element<'a, Message>;
+
+// TODO: Fix the close button on the UI card. It displays a chinese character meaning "plowed earth"?????
+pub(crate) fn view(state: &State) -> UIElement {
+    let mut elements: Vec<UIElement> = Vec::new();
+
+    // OPTIONAL Error message
+    if let Some(error_element) = spawn_error_message(state) {
+        elements.push(error_element.into());
+    }
+
+    // Elapsed Time Text
+    elements.push(elapsed_time_element(state));
+
+    // Baton Latest Send Text
+    elements.push(baton_data_element(state));
+    elements.push(baton_connect_status_element(state));
+
+    //added for tcp packet count -Nyla Hughes
+    //elements.push(tcp_packet_count_element(state));
+    // Clicks in the last 60 seconds -Nyla Hughes
+    elements.push(clicks_last_60s_element(state));
+    //
+
+    // TCP Connection Status elements
+    elements.push(tcp_connect_status_element(state));
+    elements.push(check_tcp_status_button(state));
+
+    // IPC Connect/Disconnect Buttons
+    elements.push(ipc_connect_button(state));
+    elements.push(ipc_disconnect_button(state));
+
+    // TCP Connect/Disconnect buttons
+    elements.push(tcp_connect_button(state));
+    elements.push(tcp_disconnect_button(state));
+
+    // XML popup
+    elements.push(xml_downloader_popup(state));
+
+    // Create and return the GUI column from that vector
+    column(elements).into()
+}
+
+fn spawn_error_message(state: &State) -> Option<UIElement> {
+    if let Some(error) = &state.error_message {
+        Some(
+            container(text(format!("⚠️ {}", error)))
+                .padding(10)
+                .width(Length::Fill)
+                .style(container::rounded_box)
+                .center_x(Length::Fill)
+                .into(),
+        )
+    } else {
+        None
+    }
+}
+
+fn elapsed_time_element(state: &State) -> UIElement {
+    text(format!("Elapsed time: {:?}", state.elapsed_time)).into()
+}
+
+fn baton_connect_status_element(state: &State) -> UIElement {
+    let connection_status = if state.active_baton_connection {
+        ":) Baton Connected!".to_string()
+    } else {
+        ":( No Baton Connection".to_string()
+    };
+    text(connection_status).into()
+}
+
+fn baton_data_element(state: &State) -> UIElement {
     // need to update view function with float parsing? perhaps? idk
     let baton_data = match &state.latest_baton_send {
-        Some(data) => format!("[BATON]: {data}"),
+        Some(data) => format!("[BATON]: {data:.3}"),
         None => "No data from baton.".into(),
     };
+    text(baton_data).into()
+}
 
-    // make this better. Perhaps add a funny emoji or sm
-    let baton_connect_status = if state.active_baton_connection {
-        format!("Baton Status: Connected")
+//*  amount of packets sent over TCP connection -Nyla Hughes
+// fn tcp_packet_count_element(state: &State) -> UIElement {
+   // text(format!("TCP Packets Sent:")).to_string()}
+    // will look something like text(format!("TCP Packets Sent: {}", state.tcp_packet_count)).to_string()
+    // Once implemented -Nyla Hughes *//
+//This just tracks clicks in the last 60 seconds to make sure the counting works -Nyla Hughes
+fn clicks_last_60s_element(state: &State) -> UIElement {
+    text(format!("'packets' sent in the last 60s: {}", state.clicks_last_60s)).into()
+}
+//
+
+
+
+fn tcp_connect_status_element(state: &State) -> UIElement {
+    text(format!("TCP Connection Status: {}", state.tcp_connected)).into()
+}
+
+fn check_tcp_status_button(_state: &State) -> UIElement {
+    button("Check TCP Connection Status")
+        .on_press(Message::ConnectionMessage)
+        .into()
+}
+
+fn ipc_connect_button(_state: &State) -> UIElement {
+    button("Connect IPC").on_press(Message::ConnectIpc).into()
+}
+
+fn ipc_disconnect_button(_state: &State) -> UIElement {
+    button("Disconnect IPC")
+        .on_press(Message::DisconnectIpc)
+        .into()
+}
+
+fn tcp_connect_button(state: &State) -> UIElement {
+    if state.tcp_addr_field.to_socket_addrs().is_ok() {
+        row![
+            button("Connect TCP").on_press(Message::ConnectTcp),
+            text_input("127.0.0.1:9999", &state.tcp_addr_field)
+                .on_input(|addr| Message::TcpAddrFieldUpdate(addr)),
+            text("Address input is valid")
+        ]
+        .spacing(5)
+        .into()
     } else {
-        format!("Baton Status: Disconnected")
-    };
+        row![
+            button("Connect TCP"),
+            text_input("127.0.0.1:9999", &state.tcp_addr_field)
+                .on_input(|addr| Message::TcpAddrFieldUpdate(addr)),
+            text("Address input is invalid")
+        ]
+        .spacing(5)
+        .into()
+    }
+}
 
-    let connection_status = state.tcp_connected;
+fn tcp_disconnect_button(_state: &State) -> UIElement {
+    button("Disconnect TCP")
+        .on_press(Message::DisconnectTcp)
+        .into()
+}
 
-    column![
-        text(format!("Elapsed time: {:?}", state.elapsed_time)),
-        text(baton_data),
-        text(format!("TCP Connection Status: {}", connection_status)),
-        button("Check Connection Status").on_press(Message::ConnectionMessage),
-        // if we use containers, it boxes up the text elements and makes them easier to read
-        container(text(baton_connect_status))
-            .padding(10)
-            .style(container::rounded_box),
-        button("Connect IPC").on_press(Message::ConnectIpc),
-        button("Disconnect IPC").on_press(Message::DisconnectIpc),
-        if state.tcp_addr_field.to_socket_addrs().is_ok() {
-            row![
-                button("Connect TCP").on_press(Message::ConnectTcp),
-                text_input("127.0.0.1:9999", &state.tcp_addr_field)
-                    .on_input(|addr| Message::TcpAddrFieldUpdate(addr)),
-                text("Address input is valid")
-            ]
-            .spacing(5)
-        } else {
-            row![
-                button("Connect TCP"),
-                text_input("127.0.0.1:9999", &state.tcp_addr_field)
-                    .on_input(|addr| Message::TcpAddrFieldUpdate(addr)),
-                text("Address input is invalid")
-            ]
-            .spacing(5)
-        },
-        button("Disconnect TCP").on_press(Message::DisconnectTcp),
-    ]
-    .padding(10)
-    .into()
+fn xml_downloader_popup(state: &State) -> UIElement {
+    if state.card_open {
+        container(
+            card(
+                // FIXME: reword these toggles to actually be snappy wording
+                text(format!("Download the XML File!")),
+                column![
+                    toggler(state.altitude_toggle)
+                        .label("Altitude Toggle!")
+                        .on_toggle(Message::AltitudeToggle),
+                    toggler(state.airspeed_toggle)
+                        .label("Airspeed Toggle")
+                        .on_toggle(Message::AirspeedToggle),
+                    toggler(state.vertical_airspeed_toggle)
+                        .label("Vertical Airspeed Toggle")
+                        .on_toggle(Message::VerticalAirspeedToggle),
+                    toggler(state.heading_toggle)
+                        .label("Heading Toggle")
+                        .on_toggle(Message::HeadingToggle),
+                    button("Generate XML File").on_press(Message::CreateXMLFile),
+                ],
+            )
+            .style(style::card::primary)
+            .on_close(Message::CardClose),
+        )
+        .into()
+    } else {
+        button("Open XML Download Menu")
+            .on_press(Message::CardOpen)
+            .into()
+    }
 }


### PR DESCRIPTION
**THIS IS CONCEPT OF WHAT SUPPOSED TO HAPPEN NOT FULLY DONE**

This is a quick concept of what the packet counter should look like, this includes the counter itself (but its counting clicks until packets are fully implememted) and a timer removes the clicks past 60 seconds. This is be replaced with the full implemnt of the packets rather than clicks once finished. you can try it by clicking the Check TCP Connection Status button and it will add that click to the counter then after 60 seconds itll remove it.





related to #109 

---

### **What was changed?**

Added new code in state.rs to keep track of clicks and remove old ones after 60 seconds.

changed update.rs so the counter refreshes every 10 milliseconds and records clicks when the button is pressed.
Added a new label in view.rs so the number of clicks in the last 60 seconds shows up on the screen.

---

### **Why was it changed?**

Before, the GUI didn’t show if anything was changing 

The new counter gives a simple way to see activity.

Using clicks for now makes it easy to test, and it will later show real packet counts.

---

### **How was it changed?**

Added a list that remembers the time of each click. And it checks if any clicks in older than 60 seconds and removes them 

The number of clicks left in the list is shown on the screen. 

---

### **Screenshots (if applicable):**
This first image is the "packets" but its me clicking 5 times and it shows 
<img width="447" height="320" alt="Screenshot 2025-09-15 at 3 15 13 PM" src="https://github.com/user-attachments/assets/4f3ae2c4-1f45-4c3f-a329-100595c0d581" />

This second image is how it looks after 60 seconds have passed, the counter went back to zero 
<img width="451" height="325" alt="Screenshot 2025-09-15 at 3 16 13 PM" src="https://github.com/user-attachments/assets/d8d09d5b-e044-4ee7-8489-d39c8ac1ce27" />